### PR TITLE
GOFAST-5316 - Fix space restore api documentation 'since' version

### DIFF
--- a/docs-gofast-development/api-rest.rst
+++ b/docs-gofast-development/api-rest.rst
@@ -1231,7 +1231,7 @@ Cette méthode permet de récupérer les membres d’un espace.
 Action : restore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Depuis: ``4.4.0_R2``
+Depuis: ``4.5.0``
 
 Cette action permet de restaurer un espace supprimé et ses contenus
 


### PR DESCRIPTION
Fixes "since" version of space restoration api endpoint documentation referring to outdated 4.4.0_R2 version